### PR TITLE
Updating LangChain method ahead of deprecation

### DIFF
--- a/helpers.py
+++ b/helpers.py
@@ -132,7 +132,7 @@ def chat(
             # Call the OpenAI API via LangChain
             llm_invocation = ChatOpenAI(openai_api_key=openai.api_key, model_name=model, max_tokens=max_tokens, temperature=temperature)
 
-            llm_response =llm_invocation.predict_messages([SystemMessage(content=' '.join(custom_instructions)),HumanMessage(content=' '.join(curated_datasets) + prompt)])
+            llm_response =llm_invocation.invoke([SystemMessage(content=' '.join(custom_instructions)),HumanMessage(content=' '.join(curated_datasets) + prompt)])
             response = llm_response.content
 
 
@@ -146,7 +146,7 @@ def chat(
                 HumanMessage(content=prompt)
             ]
 
-            llm_response = llm_invocation.predict_messages(messages)
+            llm_response = llm_invocation.invoke(messages)
             response = llm_response.content
 
         case "google":


### PR DESCRIPTION
Small tweak to address the following warning:
```
lib/python3.11/site-packages/langchain_core/_api/deprecation.py:119: LangChainDeprecationWarning: The method `BaseChatModel.predict_messages` was deprecated in langchain-core 0.1.7 and will be removed in 0.2.0. Use invoke instead.
  warn_deprecated(
```